### PR TITLE
Implement admin area and role-based navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,10 @@ import Professor from "./pages/Professor";
 import Aluno from "./pages/Aluno";
 import AlunoLogin from "./pages/AlunoLogin";
 import ProfessorLogin from "./pages/ProfessorLogin";
+import Admin from "./pages/Admin";
+import AdminLogin from "./pages/AdminLogin";
 import NotFound from "./pages/NotFound";
+import ProtectedRoute from "@/components/ProtectedRoute";
 
 const queryClient = new QueryClient();
 
@@ -23,10 +26,33 @@ const App = () => (
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />
-            <Route path="/professor" element={<Professor />} />
+            <Route
+              path="/professor"
+              element={
+                <ProtectedRoute requiredType="professor">
+                  <Professor />
+                </ProtectedRoute>
+              }
+            />
             <Route path="/professor/login" element={<ProfessorLogin />} />
-            <Route path="/aluno" element={<Aluno />} />
+            <Route
+              path="/aluno"
+              element={
+                <ProtectedRoute requiredType="aluno">
+                  <Aluno />
+                </ProtectedRoute>
+              }
+            />
             <Route path="/aluno/login" element={<AlunoLogin />} />
+            <Route
+              path="/admin"
+              element={
+                <ProtectedRoute requiredType="admin">
+                  <Admin />
+                </ProtectedRoute>
+              }
+            />
+            <Route path="/admin/login" element={<AdminLogin />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+
+interface SimpleUser { id: string; name: string; email: string; }
+
+const AdminDashboard = () => {
+  const [students, setStudents] = useState<SimpleUser[]>([]);
+  const [teachers, setTeachers] = useState<SimpleUser[]>([]);
+
+  useEffect(() => {
+    const alunoData = JSON.parse(localStorage.getItem('@DevVenture:alunos') || '[]');
+    const professorData = JSON.parse(localStorage.getItem('@DevVenture:professors') || '[]');
+    setStudents(alunoData);
+    setTeachers(professorData);
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 pt-20">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Resumo</CardTitle>
+          </CardHeader>
+          <CardContent className="flex space-x-8">
+            <div className="text-center">
+              <div className="text-3xl font-bold text-blue-600">{students.length}</div>
+              <div className="text-sm text-slate-600">Alunos cadastrados</div>
+            </div>
+            <div className="text-center">
+              <div className="text-3xl font-bold text-purple-600">{teachers.length}</div>
+              <div className="text-sm text-slate-600">Professores cadastrados</div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Alunos</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Nome</TableHead>
+                  <TableHead>Email</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {students.map((s: SimpleUser) => (
+                  <TableRow key={s.id}>
+                    <TableCell>{s.name}</TableCell>
+                    <TableCell>{s.email}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Professores</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Nome</TableHead>
+                  <TableHead>Email</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {teachers.map((t: SimpleUser) => (
+                  <TableRow key={t.id}>
+                    <TableCell>{t.name}</TableCell>
+                    <TableCell>{t.email}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,18 +1,32 @@
 
 import { useState } from 'react';
-import { Users, Book, User, Home, Menu, X } from 'lucide-react';
+import { Users, Book, User, Home, Menu, X, Shield } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { useAuth } from '@/contexts/AuthContext';
 
 const Navigation = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const { user, logout } = useAuth();
 
   const menuItems = [
     { name: 'Home', href: '/', icon: Home },
-    { name: 'Área do Professor', href: '/professor', icon: User },
-    { name: 'Área do Aluno', href: '/aluno', icon: Book },
-    { name: 'Login Professor', href: '/professor/login', icon: User },
-    { name: 'Login Aluno', href: '/aluno/login', icon: Book },
   ];
+
+  if (user?.type === 'professor') {
+    menuItems.push({ name: 'Área do Professor', href: '/professor', icon: User });
+  } else if (user?.type === 'aluno') {
+    menuItems.push({ name: 'Área do Aluno', href: '/aluno', icon: Book });
+  } else if (user?.type === 'admin') {
+    menuItems.push({ name: 'Admin', href: '/admin', icon: Shield });
+  }
+
+  if (!user) {
+    menuItems.push({ name: 'Login Professor', href: '/professor/login', icon: User });
+    menuItems.push({ name: 'Login Aluno', href: '/aluno/login', icon: Book });
+    menuItems.push({ name: 'Login Admin', href: '/admin/login', icon: Shield });
+  } else {
+    menuItems.push({ name: 'Sair', href: '#', icon: X, onClick: logout });
+  }
 
   return (
     <nav className="fixed top-0 w-full bg-slate-900/95 backdrop-blur-md border-b border-slate-700 z-50">
@@ -31,16 +45,27 @@ const Navigation = () => {
 
           {/* Desktop Menu */}
           <div className="hidden md:flex items-center space-x-8">
-            {menuItems.map((item) => (
-              <a
-                key={item.name}
-                href={item.href}
-                className="text-slate-300 hover:text-white transition-colors duration-200 flex items-center space-x-2"
-              >
-                <item.icon size={18} />
-                <span>{item.name}</span>
-              </a>
-            ))}
+            {menuItems.map((item) =>
+              item.onClick ? (
+                <button
+                  key={item.name}
+                  onClick={item.onClick}
+                  className="text-slate-300 hover:text-white transition-colors duration-200 flex items-center space-x-2"
+                >
+                  <item.icon size={18} />
+                  <span>{item.name}</span>
+                </button>
+              ) : (
+                <a
+                  key={item.name}
+                  href={item.href}
+                  className="text-slate-300 hover:text-white transition-colors duration-200 flex items-center space-x-2"
+                >
+                  <item.icon size={18} />
+                  <span>{item.name}</span>
+                </a>
+              )
+            )}
           </div>
 
           {/* Mobile menu button */}
@@ -59,17 +84,33 @@ const Navigation = () => {
         {/* Mobile Menu */}
         {isMenuOpen && (
           <div className="md:hidden py-4 border-t border-slate-700">
-            {menuItems.map((item) => (
-              <a
-                key={item.name}
-                href={item.href}
-                className="flex items-center space-x-3 px-4 py-2 text-slate-300 hover:text-white hover:bg-slate-800 transition-colors duration-200"
-                onClick={() => setIsMenuOpen(false)}
-              >
-                <item.icon size={18} />
-                <span>{item.name}</span>
-              </a>
-            ))}
+            {menuItems.map((item) =>
+              item.onClick ? (
+                <button
+                  key={item.name}
+                  onClick={() => {
+                    if (item.onClick) {
+                      item.onClick();
+                    }
+                    setIsMenuOpen(false);
+                  }}
+                  className="flex w-full items-center space-x-3 px-4 py-2 text-left text-slate-300 hover:text-white hover:bg-slate-800 transition-colors duration-200"
+                >
+                  <item.icon size={18} />
+                  <span>{item.name}</span>
+                </button>
+              ) : (
+                <a
+                  key={item.name}
+                  href={item.href}
+                  className="flex items-center space-x-3 px-4 py-2 text-slate-300 hover:text-white hover:bg-slate-800 transition-colors duration-200"
+                  onClick={() => setIsMenuOpen(false)}
+                >
+                  <item.icon size={18} />
+                  <span>{item.name}</span>
+                </a>
+              )
+            )}
           </div>
         )}
       </div>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -5,7 +5,7 @@ interface User {
   id: string;
   email: string;
   name: string;
-  type: 'aluno' | 'professor';
+  type: 'aluno' | 'professor' | 'admin';
 }
 
 interface StoredUser extends User {
@@ -16,8 +16,8 @@ interface StoredUser extends User {
 
 interface AuthContextData {
   user: User | null;
-  login: (email: string, password: string, type: 'aluno' | 'professor') => Promise<boolean>;
-  register: (email: string, password: string, name: string, type: 'aluno' | 'professor') => Promise<boolean>;
+  login: (email: string, password: string, type: 'aluno' | 'professor' | 'admin') => Promise<boolean>;
+  register: (email: string, password: string, name: string, type: 'aluno' | 'professor' | 'admin') => Promise<boolean>;
   logout: () => void;
   loading: boolean;
 }
@@ -41,8 +41,24 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     setLoading(false);
   }, []);
 
-  const login = async (email: string, password: string, type: 'aluno' | 'professor'): Promise<boolean> => {
+  const login = async (email: string, password: string, type: 'aluno' | 'professor' | 'admin'): Promise<boolean> => {
     try {
+      if (type === 'admin') {
+        // Admin com credenciais fixas
+        if (email === 'admin@devventure.com' && password === 'admin123') {
+          const userData: User = {
+            id: 'admin',
+            email,
+            name: 'Administrador',
+            type: 'admin'
+          };
+          setUser(userData);
+          localStorage.setItem('@DevVenture:user', JSON.stringify(userData));
+          return true;
+        }
+        return false;
+      }
+
       // Simulação de API call - em produção, substituir por chamada real
       const users: StoredUser[] = JSON.parse(localStorage.getItem(`@DevVenture:${type}s`) || '[]');
       const foundUser = users.find((u) => u.email === email);
@@ -66,8 +82,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   };
 
-  const register = async (email: string, password: string, name: string, type: 'aluno' | 'professor'): Promise<boolean> => {
+  const register = async (email: string, password: string, name: string, type: 'aluno' | 'professor' | 'admin'): Promise<boolean> => {
     try {
+      if (type === 'admin') {
+        // cadastro de administradores não permitido via app
+        return false;
+      }
       const users: StoredUser[] = JSON.parse(localStorage.getItem(`@DevVenture:${type}s`) || '[]');
       
       // Verificar se email já existe

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,0 +1,17 @@
+import Navigation from '@/components/Navigation';
+import AdminDashboard from '@/components/AdminDashboard';
+import Footer from '@/components/Footer';
+
+const Admin = () => {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navigation />
+      <main className="flex-grow">
+        <AdminDashboard />
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Admin;

--- a/src/pages/AdminLogin.tsx
+++ b/src/pages/AdminLogin.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import Navigation from '@/components/Navigation';
+import { Shield, Eye, EyeOff } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
+
+const AdminLogin = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const { login } = useAuth();
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    const success = await login(email, password, 'admin');
+    setLoading(false);
+    if (success) {
+      navigate('/admin');
+    } else {
+      alert('Credenciais inválidas');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900">
+      <Navigation />
+
+      <div className="flex items-center justify-center min-h-screen pt-16 px-4">
+        <Card className="w-full max-w-md bg-white/10 backdrop-blur-md border-white/20">
+          <CardHeader className="text-center">
+            <div className="mx-auto w-16 h-16 bg-red-500 rounded-full flex items-center justify-center mb-4">
+              <Shield className="w-8 h-8 text-white" />
+            </div>
+            <CardTitle className="text-2xl text-white">Login Admin</CardTitle>
+          </CardHeader>
+
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <Input
+                type="email"
+                placeholder="Email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="bg-white/20 border-white/30 text-white placeholder:text-white/70"
+              />
+              <div className="relative">
+                <Input
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder="Senha"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="bg-white/20 border-white/30 text-white placeholder:text-white/70 pr-10"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-white/70 hover:text-white"
+                >
+                  {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                </button>
+              </div>
+              <Button type="submit" className="w-full bg-red-600 hover:bg-red-700 text-white" disabled={loading}>
+                {loading ? 'Processando...' : 'Entrar'}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default AdminLogin;


### PR DESCRIPTION
## Summary
- add admin login/dashboard pages
- implement admin user support in auth context
- restrict routes with `ProtectedRoute`
- render navigation items based on the logged-in role

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68400ccdaef083279bc0d0e4e9f8caeb