### PR TITLE
Fix input sanitization

### DIFF
--- a/src/hooks/useFormValidation.ts
+++ b/src/hooks/useFormValidation.ts
@@ -16,9 +16,12 @@ interface ValidationRules {
 export const useFormValidation = (rules: ValidationRules) => {
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
 
-  const sanitizeInput = (value: string): string => {
-    return value
-      .trim()
+  const sanitizeInput = (value: string, preserveSpaces = false): string => {
+    let sanitized = value;
+    if (!preserveSpaces) {
+      sanitized = sanitized.trim();
+    }
+    return sanitized
       .replace(/[<>]/g, '') // Remove basic XSS characters
       .replace(/javascript:/gi, '') // Remove javascript: protocols
       .replace(/on\w+=/gi, ''); // Remove event handlers

--- a/src/pages/AlunoLogin.tsx
+++ b/src/pages/AlunoLogin.tsx
@@ -47,6 +47,10 @@ const AlunoLogin = () => {
     semestre: {
       required: !isLogin,
       message: 'Semestre é obrigatório'
+    },
+    telefone: {
+      pattern: /^[0-9\s()+-]*$/,
+      message: 'Telefone deve conter apenas números'
     }
   };
 
@@ -62,8 +66,14 @@ const AlunoLogin = () => {
     telefone: ''
   });
 
+  const preserveSpacesFields = ['name', 'telefone'];
+
   const handleInputChange = (field: string, value: string) => {
-    const sanitized = sanitizeInput(value);
+    let processedValue = value;
+    if (field === 'telefone') {
+      processedValue = processedValue.replace(/[^0-9\s()+-]/g, '');
+    }
+    const sanitized = sanitizeInput(processedValue, preserveSpacesFields.includes(field));
     setFormData(prev => ({ ...prev, [field]: sanitized }));
     validateField(field, sanitized);
   };

--- a/src/pages/ProfessorLogin.tsx
+++ b/src/pages/ProfessorLogin.tsx
@@ -48,6 +48,10 @@ const ProfessorLogin = () => {
       required: !isLogin,
       message: 'Formação é obrigatória'
     },
+    telefone: {
+      pattern: /^[0-9\s()+-]*$/,
+      message: 'Telefone deve conter apenas números'
+    },
     registro: {
       required: !isLogin,
       minLength: 3,
@@ -68,8 +72,14 @@ const ProfessorLogin = () => {
     registro: ''
   });
 
+  const preserveSpacesFields = ['name', 'formacao', 'especializacao', 'telefone'];
+
   const handleInputChange = (field: string, value: string) => {
-    const sanitized = sanitizeInput(value);
+    let processedValue = value;
+    if (field === 'telefone') {
+      processedValue = processedValue.replace(/[^0-9\s()+-]/g, '');
+    }
+    const sanitized = sanitizeInput(processedValue, preserveSpacesFields.includes(field));
     setFormData(prev => ({ ...prev, [field]: sanitized }));
     validateField(field, sanitized);
   };


### PR DESCRIPTION
## Summary
- allow preserving spaces by default with sanitizeInput options
- handle phone input digits only and allow spaces
- keep spaces for name, formation, specialization and phone fields
- validate phone input to only allow numbers and common chars

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68401a0915e08327844d3da537f8a7d8