### PR TITLE
Implement CPF input formatting and validation

### DIFF
--- a/src/hooks/useFormValidation.ts
+++ b/src/hooks/useFormValidation.ts
@@ -6,6 +6,7 @@ interface ValidationRule {
   minLength?: number;
   maxLength?: number;
   pattern?: RegExp;
+  validate?: (value: string) => boolean;
   message?: string;
 }
 
@@ -63,6 +64,11 @@ export const useFormValidation = (rules: ValidationRules) => {
       return false;
     }
 
+    if (rule.validate && !rule.validate(sanitizedValue)) {
+      setErrors(prev => ({ ...prev, [name]: rule.message || `${name} inválido` }));
+      return false;
+    }
+
     setErrors(prev => {
       const newErrors = { ...prev };
       delete newErrors[name];
@@ -81,11 +87,20 @@ export const useFormValidation = (rules: ValidationRules) => {
     return isValid;
   };
 
+  const clearFieldError = (name: string) => {
+    setErrors(prev => {
+      const newErrors = { ...prev };
+      delete newErrors[name];
+      return newErrors;
+    });
+  };
+
   return {
     errors,
     validateField,
     validateForm,
     sanitizeInput,
-    clearErrors: () => setErrors({})
+    clearErrors: () => setErrors({}),
+    clearFieldError
   };
 };

--- a/src/pages/ProfessorLogin.tsx
+++ b/src/pages/ProfessorLogin.tsx
@@ -10,6 +10,7 @@ import { useFormValidation } from '@/hooks/useFormValidation';
 import { useAuth } from '@/contexts/AuthContext';
 import Navigation from '@/components/Navigation';
 import { User, Eye, EyeOff } from 'lucide-react';
+import { formatCPF, isCPFValid } from '@/utils/cpf';
 
 const ProfessorLogin = () => {
   const [isLogin, setIsLogin] = useState(true);
@@ -37,8 +38,8 @@ const ProfessorLogin = () => {
     },
     cpf: {
       required: !isLogin,
-      pattern: /^\d{11}$/,
-      message: 'CPF deve conter 11 dígitos'
+      validate: isCPFValid,
+      message: 'CPF inválido'
     },
     especializacao: {
       required: !isLogin,
@@ -59,7 +60,7 @@ const ProfessorLogin = () => {
     }
   };
 
-  const { errors, validateForm, validateField, sanitizeInput } = useFormValidation(validationRules);
+  const { errors, validateForm, validateField, sanitizeInput, clearFieldError } = useFormValidation(validationRules);
 
   const [formData, setFormData] = useState({
     email: '',
@@ -79,6 +80,19 @@ const ProfessorLogin = () => {
     if (field === 'telefone') {
       processedValue = processedValue.replace(/[^0-9\s()+-]/g, '');
     }
+
+    if (field === 'cpf') {
+      processedValue = processedValue.replace(/\D/g, '').slice(0, 11);
+      const sanitized = sanitizeInput(processedValue);
+      setFormData(prev => ({ ...prev, [field]: sanitized }));
+      if (sanitized.length === 11) {
+        validateField(field, sanitized);
+      } else {
+        clearFieldError(field);
+      }
+      return;
+    }
+
     const sanitized = sanitizeInput(processedValue, preserveSpacesFields.includes(field));
     setFormData(prev => ({ ...prev, [field]: sanitized }));
     validateField(field, sanitized);
@@ -149,11 +163,11 @@ const ProfessorLogin = () => {
 
                   <div>
                     <Input
-                      placeholder="CPF (somente números) *"
-                      value={formData.cpf}
-                      onChange={(e) => handleInputChange('cpf', e.target.value.replace(/\D/g, ''))}
+                      placeholder="CPF *"
+                      value={formatCPF(formData.cpf)}
+                      onChange={(e) => handleInputChange('cpf', e.target.value)}
                       className="bg-white/20 border-white/30 text-white placeholder:text-white/70"
-                      maxLength={11}
+                      maxLength={14}
                     />
                     {errors.cpf && (
                       <p className="text-red-400 text-sm mt-1">{errors.cpf}</p>

--- a/src/utils/cpf.ts
+++ b/src/utils/cpf.ts
@@ -1,0 +1,27 @@
+export const formatCPF = (value: string): string => {
+  const digits = value.replace(/\D/g, '').slice(0, 11);
+  return digits
+    .replace(/(\d{3})(\d)/, '$1.$2')
+    .replace(/(\d{3})(\d)/, '$1.$2')
+    .replace(/(\d{3})(\d{1,2})$/, '$1-$2');
+};
+
+export const isCPFValid = (value: string): boolean => {
+  const cpf = value.replace(/\D/g, '');
+  if (cpf.length !== 11) return false;
+  if (/^(\d)\1{10}$/.test(cpf)) return false;
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    sum += parseInt(cpf.charAt(i)) * (10 - i);
+  }
+  let rest = sum % 11;
+  const dv1 = rest < 2 ? 0 : 11 - rest;
+  if (parseInt(cpf.charAt(9)) !== dv1) return false;
+  sum = 0;
+  for (let i = 0; i < 10; i++) {
+    sum += parseInt(cpf.charAt(i)) * (11 - i);
+  }
+  rest = sum % 11;
+  const dv2 = rest < 2 ? 0 : 11 - rest;
+  return parseInt(cpf.charAt(10)) === dv2;
+};


### PR DESCRIPTION
## Summary
- add CPF utility with formatCPF and isCPFValid
- extend form validation hook with custom validators and error clearing
- apply CPF masking and validation to professor form

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68401e2be6508327b08376f26230bd63