### PR TITLE
Fix desktop filter sidebar behavior

### DIFF
--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -507,15 +507,21 @@ const AdminDashboard = () => {
         isMobileOpen={isMobileSidebarOpen}
         toggleMobile={toggleMobileSidebar}
       />
-      <main className="flex-1 p-4 pt-20 md:p-6 md:pt-20 md:ml-64 lg:ml-72 xl:ml-80 overflow-y-auto">
-        <Button
-          className="md:hidden fixed top-20 left-4 z-30"
-          variant="outline"
-          size="icon"
-          onClick={toggleMobileSidebar}
-        >
-          <Filter size={20} />
-        </Button>
+      <main
+        className={`flex-1 p-4 pt-20 md:p-6 md:pt-20 overflow-y-auto ${
+          !isMobile && isMobileSidebarOpen ? 'md:ml-64 lg:ml-72 xl:ml-80' : ''
+        }`}
+      >
+        {!isMobileSidebarOpen && (
+          <Button
+            className="fixed top-20 left-4 z-30"
+            variant="outline"
+            size="icon"
+            onClick={toggleMobileSidebar}
+          >
+            <Filter size={20} />
+          </Button>
+        )}
         <div className="space-y-6">
         {/* Summary Card */}
         <Card>

--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -29,14 +29,11 @@ const AdminSidebar: React.FC<AdminSidebarProps> = ({
   useEffect(() => {
     const handleResize = () => {
       setIsLargeScreen(window.innerWidth > 768);
-      if (window.innerWidth > 768 && !isMobileOpen) {
-        toggleMobile();
-      }
     };
 
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, [isMobileOpen, toggleMobile]);
+  }, []);
 
   return (
     <>
@@ -49,7 +46,7 @@ const AdminSidebar: React.FC<AdminSidebarProps> = ({
 
       <Card
         className={`h-full w-64 lg:w-72 xl:w-80 bg-slate-800 border-slate-700 text-white fixed top-16 left-0 overflow-y-auto pt-4 z-40 transition-transform duration-300 ${
-          isMobileOpen || isLargeScreen ? 'translate-x-0' : '-translate-x-full'
+          isMobileOpen ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
         <CardHeader className="relative">
@@ -58,7 +55,7 @@ const AdminSidebar: React.FC<AdminSidebarProps> = ({
             Filtros Avançados
           </CardTitle>
           <button
-            className="md:hidden absolute top-4 right-4 text-slate-300 hover:text-white"
+            className="absolute top-4 right-4 text-slate-300 hover:text-white"
             onClick={toggleMobile}
           >
             <X size={24} />


### PR DESCRIPTION
## Summary
- allow closing the advanced filters sidebar on larger screens
- show filter toggle button on desktop
- adjust main content margin only when the sidebar is open

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844871553d483278f46eea1ab4e516d