### PR TITLE
feat: integrate auth API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000/api

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Projeto exclusivo da equipe Harpion desenvolvido com foco em qualidade e seguran
 ## Instalação
 1. Clone este repositório.
 2. Execute `npm install` ou `bun install` para instalar as dependências.
-3. Copie o arquivo `.env.example` para `.env` e configure suas variáveis de ambiente.
+3. Copie o arquivo `.env.example` para `.env` e configure suas variáveis de ambiente (como `VITE_API_URL` apontando para a API do Laravel).
 
 ## Ambiente de desenvolvimento
 Para iniciar o servidor de desenvolvimento execute:

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.4",
         "@tanstack/react-query": "^5.56.2",
+        "axios": "^1.11.0",
         "chart.js": "^4.4.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -3249,6 +3250,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -3285,6 +3292,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -3359,6 +3377,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -3882,6 +3913,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -4091,6 +4134,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -4117,6 +4169,20 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -4165,6 +4231,51 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -4542,6 +4653,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -4556,6 +4687,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -4622,6 +4769,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -4629,6 +4800,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -4700,6 +4884,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -4715,6 +4911,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -5039,6 +5262,15 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5059,6 +5291,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -5556,6 +5809,12 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.4",
     "@tanstack/react-query": "^5.56.2",
+    "axios": "^1.11.0",
     "chart.js": "^4.4.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,25 +1,24 @@
-
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import {
+  loginAluno,
+  loginProfessor,
+  loginAdmin,
+  registerStudent,
+  registerTeacher,
+  registerAdmin,
+  logout as serviceLogout,
+  getCurrentUser,
+  Student,
+  Teacher,
+  Admin
+} from '@/services/auth';
+import { ApiError } from '@/services/api';
 
 interface User {
   id: string;
   email: string;
   name: string;
   type: 'aluno' | 'professor' | 'admin';
-}
-
-export interface StoredUser extends User {
-  passwordHash: string;
-  salt: string;
-  createdAt: string;
-  cpf?: string;
-  ra?: string;
-  curso?: string;
-  semestre?: string;
-  telefone?: string;
-  especializacao?: string;
-  formacao?: string;
-  registro?: string;
 }
 
 export interface RegisterExtras {
@@ -40,13 +39,18 @@ interface RegisterResult {
 
 interface AuthContextData {
   user: User | null;
-  login: (email: string, password: string, type: 'aluno' | 'professor' | 'admin') => Promise<boolean>;
+  login: (
+    email: string,
+    password: string,
+    type: 'aluno' | 'professor' | 'admin'
+  ) => Promise<boolean>;
   register: (
     email: string,
     password: string,
     name: string,
     type: 'aluno' | 'professor' | 'admin',
-    extras?: RegisterExtras
+    extras?: RegisterExtras,
+    autoLogin?: boolean
   ) => Promise<RegisterResult>;
   logout: () => void;
   loading: boolean;
@@ -63,142 +67,83 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Verificar se há usuário logado no localStorage
-    const storedUser = localStorage.getItem('@DevVenture:user');
-    if (storedUser) {
-      setUser(JSON.parse(storedUser));
-    }
+    const stored = getCurrentUser();
+    if (stored) setUser(stored);
     setLoading(false);
   }, []);
 
-  const login = async (email: string, password: string, type: 'aluno' | 'professor' | 'admin'): Promise<boolean> => {
+  const login = async (
+    email: string,
+    password: string,
+    type: 'aluno' | 'professor' | 'admin'
+  ): Promise<boolean> => {
     try {
-      if (type === 'admin') {
-        // Admin com credenciais fixas
-        if (email === 'admin@devventure.com' && password === 'admin123') {
-          const userData: User = {
-            id: 'admin',
-            email,
-            name: 'Administrador',
-            type: 'admin'
-          };
-          setUser(userData);
-          localStorage.setItem('@DevVenture:user', JSON.stringify(userData));
-          return true;
-        }
-        return false;
-      }
+      let apiUser: Student | Teacher | Admin;
+      if (type === 'aluno') apiUser = await loginAluno(email, password);
+      else if (type === 'professor') apiUser = await loginProfessor(email, password);
+      else apiUser = await loginAdmin(email, password);
 
-      // Simulação de API call - em produção, substituir por chamada real
-      const users: StoredUser[] = JSON.parse(localStorage.getItem(`@DevVenture:${type}s`) || '[]');
-      const foundUser = users.find((u) => u.email === email);
-
-      if (foundUser && await verifyPassword(password, foundUser.salt, foundUser.passwordHash)) {
-        const userData: User = {
-          id: foundUser.id,
-          email: foundUser.email,
-          name: foundUser.name,
-          type
-        };
-        
-        setUser(userData);
-        localStorage.setItem('@DevVenture:user', JSON.stringify(userData));
-        return true;
-      }
-
-      // If login as 'aluno' or 'professor' failed, try admin credentials
-      if ((type === 'aluno' || type === 'professor') && email === 'admin@devventure.com' && password === 'admin123') {
-        const adminUserData: User = {
-          id: 'admin',
-          email,
-          name: 'Administrador',
-          type: 'admin'
-        };
-        setUser(adminUserData);
-        localStorage.setItem('@DevVenture:user', JSON.stringify(adminUserData));
-        return true;
-      }
-
-      return false;
+      const userData: User = {
+        id: String(apiUser.id),
+        email: apiUser.email,
+        name: apiUser.name,
+        type
+      };
+      setUser(userData);
+      localStorage.setItem('dv:user', JSON.stringify(userData));
+      return true;
     } catch (error) {
-      console.error('Erro no login:', error);
-      return false;
+      if (error instanceof ApiError) throw error;
+      throw new ApiError('Erro no login');
     }
   };
 
-const register = async (
-  email: string,
-  password: string,
-  name: string,
-  type: 'aluno' | 'professor' | 'admin',
-  extras: RegisterExtras = {},
-  autoLogin = true
-): Promise<RegisterResult> => {
+  const register = async (
+    email: string,
+    password: string,
+    name: string,
+    type: 'aluno' | 'professor' | 'admin',
+    extras: RegisterExtras = {},
+    autoLogin = true
+  ): Promise<RegisterResult> => {
     try {
-      if (type === 'admin') {
-        // cadastro de administradores não permitido via app
-        return { success: false, error: 'Cadastro de administradores não permitido' };
+      let apiUser: Student | Teacher | Admin;
+      if (type === 'aluno') {
+        apiUser = await registerStudent({ name, email, password, ...extras });
+      } else if (type === 'professor') {
+        apiUser = await registerTeacher({ name, email, password, ...extras });
+      } else {
+        apiUser = await registerAdmin({ name, email, password });
       }
-      const users: StoredUser[] = JSON.parse(localStorage.getItem(`@DevVenture:${type}s`) || '[]');
-
-      // Verificar se email já existe
-      if (users.find((u) => u.email === email)) {
-        return { success: false, error: 'E-mail já em uso' };
-      }
-
-      if (extras.cpf && users.find((u) => u.cpf === extras.cpf)) {
-        return { success: false, error: 'CPF já cadastrado' };
-      }
-
-      if (extras.ra && users.find((u) => u.ra === extras.ra)) {
-        return { success: false, error: 'RA já cadastrado' };
-      }
-
-      const { salt, hash } = await hashPassword(password);
-      const newUser: StoredUser = {
-        id: generateId(),
-        email,
-        name,
-        passwordHash: hash,
-        salt,
-        createdAt: new Date().toISOString(),
-        ...extras
-      };
-
-      users.push(newUser);
-      localStorage.setItem(`@DevVenture:${type}s`, JSON.stringify(users));
 
       const userData: User = {
-        id: newUser.id,
-        email: newUser.email,
-        name: newUser.name,
+        id: String(apiUser.id),
+        email: apiUser.email,
+        name: apiUser.name,
         type
       };
 
       if (autoLogin) {
         setUser(userData);
-        localStorage.setItem('@DevVenture:user', JSON.stringify(userData));
+        localStorage.setItem('dv:user', JSON.stringify(userData));
       }
+
       return { success: true };
     } catch (error) {
-      console.error('Erro no cadastro:', error);
+      if (error instanceof ApiError) {
+        return { success: false, error: error.message };
+      }
       return { success: false, error: 'Erro no cadastro' };
     }
   };
 
   const logout = () => {
+    serviceLogout();
     setUser(null);
-    localStorage.removeItem('@DevVenture:user');
   };
 
   return (
-    <AuthContext.Provider value={{
-      user,
-      login,
-      register,
-      logout,
-      loading
-    }}>
+    <AuthContext.Provider value={{ user, login, register, logout, loading }}>
       {children}
     </AuthContext.Provider>
   );
@@ -212,32 +157,6 @@ export const useAuth = () => {
   return context;
 };
 
-// Funções de hash e verificação de senha (simuladas)
-const generateSalt = (): string => {
-  return Math.random().toString(36).substring(2, 15);
-};
-
-const hashPassword = async (password: string, salt?: string): Promise<{ salt: string; hash: string }> => {
-  const usedSalt = salt || generateSalt();
-  const encoder = new TextEncoder();
-  const data = encoder.encode(password + usedSalt);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  const hash = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
-  return { salt: usedSalt, hash };
-};
-
-const verifyPassword = async (password: string, salt: string, hash: string): Promise<boolean> => {
-  // Em produção, usar bcrypt ou similar
-  const { hash: newHash } = await hashPassword(password, salt);
-  return newHash === hash;
-};
-
-const generateId = (): string => {
-  return Math.random().toString(36).substr(2, 9);
-};
-
-// Função para verificar a força da senha
 export const isStrongPassword = (password: string): boolean => {
   if (password.length < 8) return false;
   if (!/[A-Z]/.test(password)) return false;

--- a/src/pages/AdminLogin.tsx
+++ b/src/pages/AdminLogin.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import Navigation from '@/components/Navigation';
 import { Shield } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
+import { ApiError } from '@/services/api';
 
 const AdminLogin = () => {
   const [email, setEmail] = useState('');
@@ -15,17 +16,22 @@ const AdminLogin = () => {
   const { login } = useAuth();
   const navigate = useNavigate();
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-    const success = await login(email, password, 'admin');
-    setLoading(false);
-      if (success) {
+    const handleSubmit = async (e: React.FormEvent) => {
+      e.preventDefault();
+      setLoading(true);
+      try {
+        await login(email, password, 'admin');
         navigate('/admin/dashboard');
-    } else {
-      alert('Credenciais inválidas');
-    }
-  };
+      } catch (error) {
+        if (error instanceof ApiError) {
+          alert(error.message);
+        } else {
+          alert('Credenciais inválidas');
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900">

--- a/src/pages/AlunoLogin.tsx
+++ b/src/pages/AlunoLogin.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useFormValidation } from '@/hooks/useFormValidation';
 import { useAuth } from '@/contexts/AuthContext';
+import { ApiError } from '@/services/api';
 import Navigation from '@/components/Navigation';
 import { GraduationCap } from 'lucide-react';
 
@@ -91,7 +92,8 @@ const AlunoLogin = () => {
       let errorMsg: string | undefined;
 
       if (isLogin) {
-        success = await login(formData.email, formData.password, 'aluno');
+        await login(formData.email, formData.password, 'aluno');
+        success = true;
       } else {
         const result = await register(
           formData.email,
@@ -110,7 +112,7 @@ const AlunoLogin = () => {
       }
 
       if (success) {
-        const stored = localStorage.getItem('@DevVenture:user');
+        const stored = localStorage.getItem('dv:user');
         const loggedUser = stored ? JSON.parse(stored) : null;
         if (loggedUser?.type === 'admin') {
           navigate('/admin/dashboard');
@@ -118,11 +120,14 @@ const AlunoLogin = () => {
           navigate('/aluno');
         }
       } else {
-        alert(isLogin ? 'Credenciais inválidas' : errorMsg || 'Erro no cadastro');
+        alert(errorMsg || 'Erro no cadastro');
       }
     } catch (error) {
-      console.error('Erro:', error);
-      alert('Erro interno. Tente novamente.');
+      if (error instanceof ApiError) {
+        alert(error.message);
+      } else {
+        alert('Erro interno. Tente novamente.');
+      }
     } finally {
       setLoading(false);
     }

--- a/src/pages/ProfessorLogin.tsx
+++ b/src/pages/ProfessorLogin.tsx
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/components/ui/textarea';
 import { useFormValidation } from '@/hooks/useFormValidation';
 import { useAuth } from '@/contexts/AuthContext';
+import { ApiError } from '@/services/api';
 import Navigation from '@/components/Navigation';
 import { User } from 'lucide-react';
 import { formatCPF, isCPFValid } from '@/utils/cpf';
@@ -112,7 +113,8 @@ const ProfessorLogin = () => {
       let errorMsg: string | undefined;
 
       if (isLogin) {
-        success = await login(formData.email, formData.password, 'professor');
+        await login(formData.email, formData.password, 'professor');
+        success = true;
       } else {
         const result = await register(
           formData.email,
@@ -131,23 +133,26 @@ const ProfessorLogin = () => {
         errorMsg = result.error;
       }
 
-      if (success) {
-        const stored = localStorage.getItem('@DevVenture:user');
-        const loggedUser = stored ? JSON.parse(stored) : null;
-        if (loggedUser?.type === 'admin') {
-          navigate('/admin/dashboard');
+        if (success) {
+          const stored = localStorage.getItem('dv:user');
+          const loggedUser = stored ? JSON.parse(stored) : null;
+          if (loggedUser?.type === 'admin') {
+            navigate('/admin/dashboard');
+          } else {
+            navigate('/professor');
+          }
         } else {
-          navigate('/professor');
+          alert(errorMsg || 'Erro no cadastro');
         }
-      } else {
-        alert(isLogin ? 'Credenciais inválidas' : errorMsg || 'Erro no cadastro');
+      } catch (error) {
+        if (error instanceof ApiError) {
+          alert(error.message);
+        } else {
+          alert('Erro interno. Tente novamente.');
+        }
+      } finally {
+        setLoading(false);
       }
-    } catch (error) {
-      console.error('Erro:', error);
-      alert('Erro interno. Tente novamente.');
-    } finally {
-      setLoading(false);
-    }
   };
 
   return (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,36 @@
+import axios, { AxiosError } from 'axios';
+
+export class ApiError extends Error {
+  status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
+export const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL,
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json'
+  }
+});
+
+api.interceptors.request.use((config) => {
+  // Se tiver token, a gente manda. Caso contrário, finge que nada aconteceu.
+  const token = localStorage.getItem('dv:token');
+  if (token) config.headers.Authorization = `Bearer ${token}`;
+  return config;
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  (error: AxiosError) => {
+    const message =
+      (error.response?.data as { message?: string })?.message ||
+      error.message ||
+      'Algo deu ruim na API';
+    return Promise.reject(new ApiError(message, error.response?.status));
+  }
+);

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,108 @@
+import { api } from './api';
+
+interface BasicUser {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export interface Student extends BasicUser {
+  ra?: string;
+  curso?: string;
+  semestre?: string;
+  telefone?: string;
+}
+
+export interface Teacher extends BasicUser {
+  cpf?: string;
+  especializacao?: string;
+  formacao?: string;
+  telefone?: string;
+  registro_profissional?: string;
+}
+
+export type Admin = BasicUser;
+
+interface LoginResponse<T> {
+  message: string;
+  [key: string]: unknown;
+  aluno?: Student;
+  professor?: Teacher;
+  adm?: Admin;
+}
+
+export const loginAluno = async (email: string, password: string): Promise<Student> => {
+  const { data } = await api.post<LoginResponse<Student>>('/loginAluno', { email, password });
+  return data.aluno as Student;
+};
+
+export const loginProfessor = async (email: string, password: string): Promise<Teacher> => {
+  const { data } = await api.post<LoginResponse<Teacher>>('/loginProfessor', { email, password });
+  return data.professor ?? (data as unknown as Teacher);
+};
+
+export const loginAdmin = async (email: string, password: string): Promise<Admin> => {
+  const { data } = await api.post<LoginResponse<Admin>>('/loginAdmin', { email, password });
+  return data.adm as Admin;
+};
+
+export interface StudentPayload {
+  name: string;
+  email: string;
+  password: string;
+  ra?: string;
+  curso?: string;
+  semestre?: string;
+  telefone?: string;
+}
+
+export interface TeacherPayload {
+  name: string;
+  email: string;
+  password: string;
+  cpf: string;
+  especializacao: string;
+  formacao: string;
+  telefone?: string;
+  registro: string;
+}
+
+export interface AdminPayload {
+  name: string;
+  email: string;
+  password: string;
+}
+
+export const registerStudent = async (payload: StudentPayload): Promise<Student> => {
+  const { data } = await api.post<Student>('/aluno', payload);
+  const alunos: Student[] = JSON.parse(localStorage.getItem('@DevVenture:alunos') || '[]');
+  alunos.push(data);
+  localStorage.setItem('@DevVenture:alunos', JSON.stringify(alunos));
+  return data;
+};
+
+export const registerTeacher = async (payload: TeacherPayload): Promise<Teacher> => {
+  const body = { ...payload, registro_profissional: payload.registro };
+  delete (body as { registro?: string }).registro;
+  const { data } = await api.post<Teacher | { professor: Teacher }>('/cadastroProfessor', body);
+  const teachers: Teacher[] = JSON.parse(localStorage.getItem('@DevVenture:professors') || '[]');
+  const professor = (data as { professor?: Teacher }).professor ?? (data as Teacher);
+  teachers.push(professor);
+  localStorage.setItem('@DevVenture:professors', JSON.stringify(teachers));
+  return professor;
+};
+
+export const registerAdmin = async (payload: AdminPayload): Promise<Admin> => {
+  const { data } = await api.post<Admin | { adm: Admin }>('/cadastroAdm', payload);
+  return (data as { adm?: Admin }).adm ?? (data as Admin);
+};
+
+export const getCurrentUser = () => {
+  const stored = localStorage.getItem('dv:user');
+  return stored ? (JSON.parse(stored) as BasicUser) : null;
+};
+
+export const logout = () => {
+  localStorage.removeItem('dv:user');
+  localStorage.removeItem('dv:token');
+};


### PR DESCRIPTION
## Summary
- centralize axios client and error handling
- connect login and signup screens to Laravel API while keeping localStorage for admin
- sync dashboard users with backend

## Testing
- `npm run lint`
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad41da5e5c83279512262262627159